### PR TITLE
Allow the `prop` function to be overriden

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+install:
+ - "yarn"
+node_js:
+  - "8"
+  - "node"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Expressions
 
 There are only 2 types: numbers and strings. Numbers may be floating point or integers. Boolean logic is applied on the truthy value of values (e.g. any non-zero number is true, any non-empty string is true, otherwise false).
 
+Okay, I lied to you, there are also objects whose properties can be accessed by the `of` operator. And there's undefined. But everything else is just numbers and strings!
+
 Values | Description
 --- | ---
 43, -1.234 | Numbers
@@ -130,12 +132,45 @@ function strlen(s) {
 
 // Compile expression to executable function
 var myfilter = compileExpression(
-                    'strlen(firstname) > 5',
-                    {strlen:strlen}); // custom functions
+  'strlen(firstname) > 5',
+  { strlen } // custom functions
+);
 
 myfilter({firstname:'Joe'});    // returns 0
 myfilter({firstname:'Joseph'}); // returns 1
 ```
+
+Custom property function
+------------------------
+
+If you want to do some more magic with your expression, you can supply a custom function that will resolve the identifiers used in the expression and assign them a value yourself. The so-called property function is passed as the third argument to `compileExpression` and has the following signature:
+
+```typescript
+function propFunction(
+  propertyName: string, // name of the property being accessed
+  get: (name: string) => obj[name], // safe getter that retrieves the property from obj
+  obj: any // the object passed to compiled expression
+)
+```
+
+For example, this can be useful when you're filtering based on whether a string contains some words or not:
+
+```javascript
+function containsWord(string, word) {
+  // your optimized code
+}
+
+let myfilter = compileExpression(
+  'Bob and Alice or Cecil', {},
+  (word, _, string) => containsWord(string, word)
+);
+
+myfilter("Bob is boring"); // returns 0
+myfilter("Bob met Alice"); // returns 1
+myfilter("Cecil is cool"); // returns 1
+```
+
+**Safety note:** The `get` function returns `undefined` for properties that are defined on the object's prototype, not on the object itself. This is important, because otherwise the user could access things like `toString.constructor` and maybe do some nasty things with it. Bear this in mind if you decide not to use `get` and access the properties yourself.
 
 FAQ
 ---

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "test":  "./node_modules/mocha/bin/mocha test",
     "debug": "./node_modules/mocha/bin/mocha test --inspect-brk"
-
   },
   "dependencies": {
     "jison": "^0.4.18"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test"
+    "test":  "./node_modules/mocha/bin/mocha test",
+    "debug": "./node_modules/mocha/bin/mocha test --inspect-brk"
+
   },
   "dependencies": {
     "jison": "^0.4.18"

--- a/src/filtrex.d.ts
+++ b/src/filtrex.d.ts
@@ -58,5 +58,10 @@ export function compileExpression(
     expression: string,
     extraFunctions?: {
         [T: string]: Function
-    }
-): (obj: {}) => any
+    },
+    customProp?: (
+        name: string,
+        get: (name: string) => any,
+        object: any
+    ) => any
+): (obj: any) => any

--- a/test/misc.js
+++ b/test/misc.js
@@ -64,5 +64,15 @@ describe('Various other things', () => {
         expect( compileExpression('triple(v)', {triple})({v:7}) ).equals(21);
     });
 
+    it('custom property function', () => {
+        var textToSearch = "able was i ere I saw elba\nthe Rain in spain falls MAINLY on the plain";
+        function doesTextMatch(obj, name) { return textToSearch.indexOf(name) != -1; };
+        expect( compileExpression('able and was and i', undefined, doesTextMatch)() ).equals(1);
+        expect( compileExpression('able and was and dog', undefined, doesTextMatch)() ).equals(0);
+        expect( compileExpression('able or dog', undefined, doesTextMatch)() ).equals(1);
+        expect( compileExpression('able', undefined, doesTextMatch)() ).equals(true);
+        expect( compileExpression('Rain and (missing or MAINLY)', undefined, doesTextMatch)() ).equals(1);
+        expect( compileExpression('NotThere or (missing or (falls and plain))', undefined, doesTextMatch)() ).equals(1);
+    });
 
 });

--- a/test/misc.js
+++ b/test/misc.js
@@ -60,19 +60,58 @@ describe('Various other things', () => {
     });
 
     it('custom functions', () => {
-        function triple(x) { return x * 3; };
+        let triple = x => x * 3;
         expect( compileExpression('triple(v)', {triple})({v:7}) ).equals(21);
     });
 
-    it('custom property function', () => {
-        var textToSearch = "able was i ere I saw elba\nthe Rain in spain falls MAINLY on the plain";
-        function doesTextMatch(obj, name) { return textToSearch.indexOf(name) != -1; };
-        expect( compileExpression('able and was and i', undefined, doesTextMatch)() ).equals(1);
-        expect( compileExpression('able and was and dog', undefined, doesTextMatch)() ).equals(0);
-        expect( compileExpression('able or dog', undefined, doesTextMatch)() ).equals(1);
-        expect( compileExpression('able', undefined, doesTextMatch)() ).equals(true);
-        expect( compileExpression('Rain and (missing or MAINLY)', undefined, doesTextMatch)() ).equals(1);
-        expect( compileExpression('NotThere or (missing or (falls and plain))', undefined, doesTextMatch)() ).equals(1);
+    it('custom property function basics', () => {
+        expect(
+            compileExpression('a', {}, name => name === 'a')()
+        ).equals(1);
+
+        expect(
+            compileExpression('a + bb + ccc', {}, name => name.length)()
+        ).equals(6);
+
+        expect(
+            compileExpression('a + b * c', {}, (name, get) => get(name))
+            ({ a:1, b:2, c:3 })
+        ).equals(7);
+
+        expect(
+            compileExpression('a', {}, (name, get) => get(name))({ a:true })
+        ).equals(1);
+
+        let object = {a:1};
+        expect(
+            compileExpression('a', {}, (_,__,obj) => obj === object)(object)
+        ).equals(1);
+    });
+
+    it('custom property function text search', () => {
+        let textToSearch = "able was i ere I saw elba\nthe Rain in spain falls MAINLY on the plain";
+        let doesTextMatch = name =>  textToSearch.indexOf(name) !== -1;
+        let evalProp = exp => compileExpression(exp, undefined, doesTextMatch)();
+        
+
+        expect( evalProp('able and was and i') ).equals(1);
+        expect( evalProp('able and was and dog') ).equals(0);
+        expect( evalProp('able or dog') ).equals(1);
+        expect( evalProp('able') ).equals(1);
+        expect( evalProp('Rain and (missing or MAINLY)') ).equals(1);
+        expect( evalProp('NotThere or missing or falls and plain') ).equals(1);
+    });
+
+    it('custom property function proxy', () => {
+        let prefixedName = (str, sub) => str.substr(0, sub.length) === sub && str.substr(sub.length);
+        let tripleName = str => prefixedName(str, 'triple_');
+
+        let proxy = (name, get) => tripleName(name) ? 3 * get(tripleName(name)) : get(name);
+        let evalProp = exp => compileExpression(exp, {}, proxy)({ a:1, b:2, c:3 });
+
+        expect( evalProp('a') ).equals(1);
+        expect( evalProp('triple_a') ).equals(3);
+        expect( evalProp('a + triple_b * c') ).equals(19);
     });
 
 });

--- a/test/security.js
+++ b/test/security.js
@@ -56,6 +56,7 @@ describe('Security', () => {
         expect( global.p0wned ).equals(false);
     });
 
+
     it('does backslash escaping', () =>
         expect( compileExpression(`"\\" + '\\'`)({'\\':'good'}) ).equals('\\good')
     );
@@ -66,5 +67,13 @@ describe('Security', () => {
         expect( compileExpression('"aa" in ("bb", "cc")')() ).equals(0);
         delete Object.prototype.aa;
     });
+
+
+    it('blocks prototype access in custom property function', () => {
+        expect(
+            compileExpression('a', {}, (name, get) => get(name))
+            (Object.create({ a:1 }))
+        ).equals(undefined);
+    })
 
 });


### PR DESCRIPTION
This PR adds the ability to add custom `prop` function which would allow for some cool stuff like:
```javascript
let customProp = (obj, name) => name.length;
let expr = "foo + dingus";

compileExpression(expr, {}, customProp); //3 + 6 = 9
```

We need to add tests before merging.