### PR TITLE
in operator should support array type variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test":  "./node_modules/mocha/bin/mocha test",
+    "test": "./node_modules/mocha/bin/mocha test",
     "debug": "./node_modules/mocha/bin/mocha test --inspect-brk"
   },
   "dependencies": {

--- a/src/filtrex.js
+++ b/src/filtrex.js
@@ -210,8 +210,8 @@ function filtrexParser() {
                 ['argsList , e', code([1, ',', 3], true)],
             ],
             inSet: [
-                ['e', code(['o ==', 1], true)],
-                ['inSet , e', code([1, '|| o ==', 3], true)],
+                ['e', code(['!Array.isArray(o) ? o == ', 1, ': o.indexOf(', 1, ') >= 0'])],
+                ['inSet , e', code([1, '|| (!Array.isArray(o) ? o == ', 3 ,': o.indexOf(', 3, ') >= 0)'], true)],
             ],
             array: [
                 ['e', code([1])],


### PR DESCRIPTION
Here is a sample code
```typescript
import * as assert from "assert";
import {compileExpression} from "filtrex";

const filter = compileExpression('tags in ("a", "b", "c")');

assert.equal(filter({tags:["a", "b"] }), 1);
assert.equal(filter({tags:["d"] }), 0);

```

The behavior is similar to Jira's query language.